### PR TITLE
Kale functionality included for stop/start, resource plots

### DIFF
--- a/MNIST_Widgets.ipynb
+++ b/MNIST_Widgets.ipynb
@@ -24,9 +24,9 @@
    "source": [
     "job_name = \"isc_ihpc_mnist\"\n",
     "nodes = 1\n",
-    "engines = 1\n",
     "module = \"python/3.6-anaconda-4.4\"\n",
-    "conda_env = \"/global/cscratch1/sd/sfarrell/conda/isc-ihpc\""
+    "conda_env = \"/global/cscratch1/sd/sfarrell/conda/isc-ihpc\"\n",
+    "cluster_id=None"
    ]
   },
   {
@@ -53,15 +53,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cluster_id = None"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Connect to IPP controller\n",
     "import time\n",
     "import ipyparallel as ipp\n",
@@ -72,10 +63,7 @@
     "while retries > 0:\n",
     "    print(\"checking ipcontroller...\")\n",
     "    try:\n",
-    "        if cluster_id is not None:\n",
-    "            c = ipp.Client(cluster_id=cluster_id)\n",
-    "        else:\n",
-    "            c = ipp.Client()\n",
+    "        c = ipp.Client(cluster_id=cluster_id)\n",
     "        print(\"ipcontroller is running\")\n",
     "        break\n",
     "    except Exception as e:\n",
@@ -91,7 +79,8 @@
     "        print(\"engines are not registered yet with controller, waiting {} seconds before retry...\".format(wait_time))\n",
     "        time.sleep(wait_time)\n",
     "        retries -= 1\n",
-    "    elif len(c.ids) < engines:\n",
+    "    elif len(c.ids) < nodes:\n",
+    "        print(c.ids)\n",
     "        print(\"not all engines have registered, waiting {} seconds...\".format(wait_time))\n",
     "        time.sleep(wait_time)\n",
     "    else:\n",
@@ -188,11 +177,32 @@
     ")\n",
     "\n",
     "hpo_params = dict(\n",
-    "    h1=grid_h1,\n",
-    "    h2=grid_h2,\n",
-    "    h3=grid_h3,\n",
-    "    dropout=grid_dropout,\n",
-    "    optimizer=grid_optimizer\n",
+    "    h1=dict(\n",
+    "        values=grid_h1,\n",
+    "        default=grid_h1[0],\n",
+    "        type=int\n",
+    "    ),\n",
+    "    h2=dict(\n",
+    "        values=grid_h2,\n",
+    "        default=grid_h2[0],\n",
+    "        type=int\n",
+    "    ),\n",
+    "    h3=dict(\n",
+    "        values=grid_h3,\n",
+    "        default=grid_h3[0],\n",
+    "        type=int\n",
+    "    ),\n",
+    "    dropout=dict(\n",
+    "        values=grid_dropout,\n",
+    "        default=grid_dropout[0],\n",
+    "        type=float\n",
+    "    ),\n",
+    "    optimizer=dict(\n",
+    "        values=grid_optimizer,\n",
+    "        default=grid_optimizer[0],\n",
+    "        type=str,\n",
+    "        options=['Adadelta', 'Adam', 'Nadam']\n",
+    "    )\n",
     ")\n",
     "\n",
     "psw = ParamSpanWidget(\n",
@@ -209,7 +219,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "psw.debug"
@@ -285,6 +297,39 @@
     "%%bash -s \"{job_id}\"\n",
     "scancel $1"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Retrieve model results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table_data = psw.param_table.get_changed_df()\n",
+    "params = [k for k in psw.compute_params]\n",
+    "model_results = {}\n",
+    "\n",
+    "for i in range(len(psw.model_data)):\n",
+    "    model_results[i] = {\n",
+    "        \"parameters\": table_data.loc[i, params].to_dict(),\n",
+    "        \"history\": psw.model_data[i].get_plot_data()\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_results"
+   ]
   }
  ],
  "metadata": {
@@ -303,7 +348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/hpo_widgets.py
+++ b/hpo_widgets.py
@@ -1,4 +1,5 @@
 # stdlib
+import concurrent.futures
 import copy
 import threading
 import time
@@ -13,6 +14,9 @@ import numpy as np
 import pandas as pd
 import qgrid
 
+from kale.services.worker import KaleWorkerClient
+from kale.services.manager import KaleManagerClient
+from kale.widgets import KaleWorkerResourcesBoard
 
 class ModelPlot(ipw.VBox):
     def __init__(self, y, x=None, xlim=None, ylim=None, xlabel=None, ylabel=None, title=None):
@@ -64,7 +68,7 @@ class ModelPlot(ipw.VBox):
         self.fig = bq.Figure(
             marks=self.lines + self.scatters, 
             axes=[self.xax, self.yax], 
-            layout=ipw.Layout(height='550px', width='100%'),
+            layout=ipw.Layout(height='500px', width='100%', overflow_x='hidden'),
             title=self.title)
         self.debug = ipw.Output(layout=ipw.Layout(height='100px', overflow_y='scroll'))
         self.children = [self.fig]
@@ -142,6 +146,62 @@ class ModelPlot(ipw.VBox):
             self.debug.append_stdout("Data: {}\n".format(data))
 
 
+class ModelParamEditor(ipw.HBox):
+    def __init__(self, callback, params, layout=None):
+        super().__init__()
+        
+        self._callback = callback
+        self._params = params
+        self._layout = None
+        self._inputs = {}
+        
+        self._model_id = ipw.Label(value="Model {}".format(0))
+        
+        for k in self._params:
+            if "options" in self._params[k]:
+                self._inputs[k] = ipw.Dropdown(
+                    description = k, 
+                    disabled = False, 
+                    options = self._params[k]["options"], 
+                    value = self._params[k]["default"])
+                continue
+            
+            if self._params[k]["type"] == int:
+                self._inputs[k] = ipw.IntText(description=k, disabled=False, value=self._params[k]["default"])
+            elif self._params[k]["type"] == float:
+                self._inputs[k] = ipw.FloatText(description=k, disabled=False, value=self._params[k]["default"])
+            elif self._params[k]["type"] == bool:
+                self._inputs[k] = ipw.Checkbox(description=k, disabled=False, value=self._params[k]["default"])
+            else:
+                self._inputs[k] = ipw.Text(description=k, disabled=False, value=str(self._params[k]["default"]))
+        
+        _children = [ipw.HBox([self._model_id])]
+        param_display_row = []
+        for k,v in self._inputs.items():
+            param_display_row.append(v)
+            if len(param_display_row) == 3:
+                _children.append(ipw.HBox(param_display_row))
+                param_display_row = []
+        if len(param_display_row) > 0:
+            _children.append(ipw.HBox(param_display_row))
+        
+        self.children = [ipw.VBox(_children)]
+        self.layout.display = 'none'
+    
+    def display(self, row_id, model_id, values):
+        self._model_id.value = "Model {}".format(model_id)
+        for k in values:
+            self._inputs[k].value = values[k]
+
+    def toggle_disabled(self):
+        self._model_id.disabled = not self._model_id.disabled
+        for k in self._inputs:
+            self._inputs[k].disabled = not self._inputs[k].disabled
+            
+    def get_values(self):
+        return {k: self._inputs[k].value for k in self._inputs}
+
+
 class ParamSpanWidget(ipw.VBox):
     def __init__(self, compute_func, vis_func, params, columns=None, ipp_cluster_id=None, 
                  output_layout=None, qgrid_layout=None):
@@ -153,7 +213,8 @@ class ParamSpanWidget(ipw.VBox):
         function that produces a visualization of the model output (e.g. ModelPlot)
 
         params: dict
-        grid search parameters, either lists/numpy arrays or list of lists/2D numpy arrays, where the outer lists have the same length
+        grid search parameters, either lists/numpy arrays or list of lists/2D numpy arrays, 
+        where the outer lists have the same length
         
         ipp_cluster_id: str
         optional ipyparallel cluster id for connecting to a specific controller
@@ -163,19 +224,36 @@ class ParamSpanWidget(ipw.VBox):
         self.compute_func = compute_func
         self.vis_func = vis_func
         self.output_layout = output_layout or \
-            ipw.Layout(height='600px', border='1px solid', overflow_x='scroll', overflow_y='scroll')
+            ipw.Layout(height='500px', 
+                       border='1px solid', overflow_x='hidden', overflow_y='scroll')
         self.debug_layout = ipw.Layout(height='500px', border='1px solid', overflow_x='scroll', overflow_y='scroll')
-        self.qgrid_layout = qgrid_layout or ipw.Layout()
+        self.qgrid_layout = qgrid_layout or \
+            ipw.Layout(height='500px', overflow_y='scroll')
+        self.layout = ipw.Layout(height='auto', min_height='1050px', max_height='3000px', overflow_y='scroll')
 
         list_params = {}
         for k in params:
-            if type(params[k]) is np.ndarray:
-                list_params[k] = params[k].tolist()
+            if type(params[k]["values"]) is np.ndarray:
+                list_params[k] = params[k]["values"].tolist()
             else:
-                list_params[k] = list(params[k])
+                list_params[k] = list(params[k]["values"])
 
         self.compute_params = list_params
         self.columns = ["status", "epoch"] + [k for k in params] + ["loss", "val_loss", "acc", "val_acc"]
+        
+        self._param_definitions = {}
+        for k in params:
+            self._param_definitions[k] = {}
+            
+            if "default" in params[k]:
+                self._param_definitions[k]["default"] = params[k]["default"]
+            else:
+                self._param_definitions[k]["default"] = list_params[k][0]
+                
+            self._param_definitions[k]["type"] = params[k]["type"]
+            
+            if "options" in params[k]:
+                self._param_definitions[k]["options"] = params[k]["options"]
 
         display_params = copy.deepcopy(list_params)
         for k in display_params:
@@ -192,33 +270,65 @@ class ParamSpanWidget(ipw.VBox):
         self.params_df["status"] = ["Not Started"] * self.params_df.shape[0]
         self.params_df["epoch"] = [-1] * self.params_df.shape[0]
 
-        # create the plot output and debug output widgets
-        self.output = ipw.Output(layout=self.output_layout)
+        # create the model plot, resources, and debug output widgets
+        self.plot_output = ipw.Output(layout=self.output_layout)
+        self.resources_output = ipw.Output(layout=self.output_layout)
         self.debug = ipw.Output(layout=self.debug_layout)
+
+        self.debug.append_stdout("compute_params: {}".format(self.compute_params))
+
+        self._grid_options = {
+            "defaultColumnWidth": 200,
+            "forceFitColumns": True,
+            "editable": False,
+            "minVisibleRows": 10,
+            "maxVisibleRows": 30
+        }
         
         # create the table widget
-        self.param_table = qgrid.QGridWidget(df=self.params_df, layout=self.qgrid_layout)
-        self.param_table.grid_options['defaultColumnWidth'] = 200
-        self.param_table.grid_options['forceFitColumns'] = True
-        self.param_table.grid_options['editable'] = False
+        self.param_table = qgrid.QGridWidget(
+            df=self.params_df, 
+            grid_options=self._grid_options,
+            layout=self.qgrid_layout)
 
         # add event listeners to the table
         self.add_handlers()
 
         # add buttons for stopping and restarting runs
-        self._stop_btn = ipw.Button(description="Stop selected")
+        self._stop_btn = ipw.Button(description="Stop")
         self._stop_btn.on_click(self.stop_selected_models)
-        self._restart_btn = ipw.Button(description="Restart selected")
+        self._restart_btn = ipw.Button(description="Restart")
         self._restart_btn.on_click(self.restart_selected_models)
-
+        self._edit_selected_rows = ModelParamEditor(
+            self.update_row, 
+            self._param_definitions,
+            layout=ipw.Layout(height='300px', border='1px solid', overflow_x='scroll', overflow_y='scroll'))
+        self.controls = ipw.VBox([
+            ipw.HBox([self._stop_btn, self._restart_btn], layout=ipw.Layout(height='50px')),
+            ipw.HBox([self._edit_selected_rows])
+        ])
+        self.controls.layout.display = 'none'
+        self._restart_btn.disabled = True
+        self._stop_btn.disabled = True
+        
+        self._model_tabs = ipw.Tab([self.plot_output, self.resources_output])
+        self._model_tabs.set_title(0, "Model Results")
+        self._model_tabs.set_title(1, "Resource Usage")
+        
         # Add the widgets to this container
-        self.children = [self.output, ipw.HBox([self._stop_btn, self._restart_btn]), self.param_table]
+        self.children = [
+            self._model_tabs, 
+            self.controls, 
+            self.param_table
+        ]
         
         # store all the model related elements and futures
         self._num_models = self.param_table.get_changed_df().shape[0]
         self.model_plots = [self.vis_func(title="Model {}: {}".format(i, 
                 {k: self.compute_params[k][i] for k in self.compute_params})) for i in range(self._num_models)]
+        self.model_resource_plots = [KaleWorkerResourcesBoard() for i in range(self._num_models)]
         self.model_displays = [None for i in range(self._num_models)]
+        self.model_resource_displays = [None for i in range(self._num_models)]
         self.model_data = [
             ModelTaskData(["epoch","loss","val_loss","acc","val_acc"],["status","epoch"]) for i in range(self._num_models)]
         self._model_controller = ModelController(ipp_cluster_id=ipp_cluster_id)
@@ -226,6 +336,7 @@ class ParamSpanWidget(ipw.VBox):
         # select the first row by default
         self._active_plot = 0
         self.param_table._handle_qgrid_msg_helper({'type': 'selection_changed', 'rows': [0]})
+        self.param_table._rebuild_widget()
         
         self._stop_updates = threading.Event()
         self._stop_updates.clear()
@@ -234,11 +345,13 @@ class ParamSpanWidget(ipw.VBox):
 
     def add_handlers(self):
         """Add event handlers to the table"""
-        self.param_table.on('selection_changed', self.display_visualization)
+        self.param_table.on('selection_changed', self.display_selected)
+        self.param_table.on('All', self._debug_events)
 
     def remove_handlers(self):
         """Remove event handlers from the table"""
-        self.param_table.off('selection_changed', self.display_visualization)
+        self.param_table.off('selection_changed', self.display_selected)
+        self.param_table.off('All', self._debug_events)
         
     def submit_computations(self):
         """Start all models"""
@@ -249,7 +362,9 @@ class ParamSpanWidget(ipw.VBox):
                     self.compute_func, 
                     {k: self.compute_params[k][i] for k in self.compute_params})
         except Exception as e:
-            self.debug.append_stdout("Exception while submitting runs: {}\n".format(e.args))
+            self.debug.append_stdout("Exception while submitting runs: {} - {}\n".format(
+                e.args, 
+                traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__)))
 
     def update_data(self, interval=1):
         try:
@@ -258,7 +373,8 @@ class ParamSpanWidget(ipw.VBox):
 
                 for model_id in active_models:
                     data = active_models[model_id].data
-                    table_updated = False
+                    latest_values = self.param_table.get_changed_df()
+                    updated_values = {}
                     
                     if len(data) == 0:
                         continue
@@ -283,47 +399,67 @@ class ParamSpanWidget(ipw.VBox):
                                 self.model_plots[model_id].update(self.model_data[model_id].get_plot_data())
 
                             for k in data["history"]:
-                                self.param_table._handle_qgrid_msg_helper({
-                                    'type': 'cell_change',
-                                    'column': k,
-                                    'row_index': model_id,
-                                    'unfiltered_index': model_id,
-                                    'value': data["history"][k][-1]
-                                })
-                            table_updated = True
+                                updated_values[k] = data["history"][k][-1]
+                                
+                    if "status" in data and latest_values["status"][model_id] != data["status"]:
+                        updated_values["status"] = data["status"]
+                                            
+                    if "epoch" in data and latest_values["epoch"][model_id] != data["epoch"]:
+                        updated_values["epoch"] = data["epoch"]
 
-                    if "status" in data and self.param_table.get_changed_df()["status"][model_id]:
-                        self.param_table._handle_qgrid_msg_helper({
-                            'type': 'cell_change',
-                            'column': "status",
-                            'row_index': model_id,
-                            'unfiltered_index': model_id,
-                            'value': data["status"]
-                        })
-                        table_updated = True
-                        
-                        if data["status"] == "Ended Training":
+                    if len(updated_values) > 0:
+                        self.update_row(model_id, updated_values)
+
+                        if "status" in updated_values and updated_values["status"] == "Ended Training":
                             self._model_controller.set_model_completed(model_id)
-                    
-                    if "epoch" in data:
-                        self.param_table._handle_qgrid_msg_helper({
-                            'type': 'cell_change',
-                            'column': "epoch",
-                            'row_index': model_id,
-                            'unfiltered_index': model_id,
-                            'value': data["epoch"]
-                        })
-                        table_updated = True
-
-                    if table_updated:
-                        self.param_table._update_table()                                        
-
+                            
+                            if self._active_plot == model_id:
+                                self.display_selected({'old': [model_id], 'new': [model_id]}, self.param_table, refresh=True)
+                        
+                        self.update_resources(model_id)
                 time.sleep(interval)
         except Exception as e:
-            self.debug.append_stdout("Exception while applying updates from futures: {}\n".format(traceback.format_exc(e)))
+            self.debug.append_stdout("Exception while applying updates from futures: {}\n".format(
+                traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__)))
+    
+    def update_row(self, model_id, data):
+        try:
+            self.debug.append_stdout("update_row - model: {}, data:{}\n".format(model_id, data))
+            row_id = self.param_table.get_changed_df().index[model_id]
 
+            for k in data:
+                self.param_table._handle_qgrid_msg_helper({
+                    'type': 'cell_change',
+                    'column': k,
+                    'row_index': row_id,
+                    'unfiltered_index': model_id,
+                    'value': data[k]
+                })
+            self.param_table._update_table()
+        except Exception as e:
+            self.debug.append_stdout("Exception while updating a table row : data={} {}\n".format(
+                data,
+                traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__)))            
 
-    def display_visualization(self, event, widget_instance):
+    def update_resources(self, model_id):
+        try:
+            self.debug.append_stdout("update_resources - model: {}\n".format(model_id))            
+            resource_update = self.get_resource_usage(model_id)
+            #self.debug.append_stdout("update_resources - model: {}, data: {}\n".format(model_id, resource_update))
+            self.model_resource_plots[model_id].update(resource_update)
+        except Exception as e:
+            self.debug.append_stdout("Exception while updating model resources plot : model={}, {}\n".format(
+                model_id,
+                traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__)))
+    
+    def _debug_events(self, event, widget_instance):
+        try:
+            self.debug.append_stdout("Event received: {}\n".format(event))
+        except Exception as e:
+            self.debug.append_stdout("Exception while receiving an Event : {}\n".format(
+                traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__)))
+
+    def display_selected(self, event, widget_instance, refresh=False):
         try:
             self.debug.append_stdout("Event received: {}\n".format(event))
 
@@ -333,42 +469,174 @@ class ParamSpanWidget(ipw.VBox):
 
             row_id = event['new'][0]
             model_id = self.param_table.get_changed_df().index[row_id]
+            self._display_plot(model_id, refresh)
+            self._display_controls(model_id)
+            self._display_resources(model_id)
+        except Exception as e:
+            self.debug.append_stdout("Exception while updating plot and controls: {}\n".format(
+                traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__)))
+
+    def _display_plot(self, model_id, refresh=False):
+        try:
             self._active_plot = model_id
-                        
-            # only update the plot if there is more data since the last viewing
-            if self.model_data[model_id].num_data_rows > len(self.model_plots[model_id].lines[0].y):
+
+            # only update the plot if there is more data since the last viewing, or if a new model is running
+            if refresh or self.model_data[model_id].num_data_rows > len(self.model_plots[model_id].lines[0].y):
                 plot_data = self.model_data[model_id].get_plot_data()
                 self.model_plots[model_id].update(plot_data)
             
-            with self.output:
+            with self.plot_output:
                 clear_output(wait=True)
                 if self.model_displays[model_id] is None:
                     self.model_displays[model_id] = display(self.model_plots[model_id], display_id=True)
                 else:
                     update_display(self.model_plots[model_id], display_id=self.model_displays[model_id])
         except Exception as e:
-            self.debug.append_stdout("Exception while switching to plot {}: {}\n".format(event, e.args))
+            self.debug.append_stdout("Exception while switching to plot {}: {}\n".format(
+                model_id,
+                traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__))
+            )
 
+    def _display_controls(self, model_id):
+        try:
+            # update buttons and editor
+            self.controls.layout.display = 'inherit'
+            table_data = self.param_table.get_changed_df()
+            row_id = table_data.index[model_id]
+            status = table_data.loc[row_id, "status"]
+            #self.debug.append_stdout("{}".format(status))
+            if status not in ["Stopped", "Ended Training"]:
+                self._restart_btn.disabled = True
+                self._stop_btn.disabled = False
+                self._edit_selected_rows.layout.display = 'none'
+            else:
+                self._restart_btn.disabled = False
+                self._stop_btn.disabled = True
+                self._edit_selected_rows.layout.display = 'inherit'            
+                param_keys = [k for k in self.compute_params]
+                params = table_data.loc[row_id, param_keys].to_dict()
+                self._edit_selected_rows.display(row_id, model_id, params)
+        except Exception as e:
+            self.debug.append_stdout("Exception while updating controls: {}\n".format(
+                traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__)))
+
+    def _display_resources(self, model_id):
+        try:
+            with self.resources_output:
+                clear_output(wait=True)
+                if self.model_resource_displays[model_id] is None:
+                    self.model_resource_displays[model_id] = display(self.model_resource_plots[model_id], display_id=True)
+                else:
+                    update_display(self.model_resource_plots[model_id], display_id=self.model_resource_displays[model_id])
+        except Exception as e:
+            self.debug.append_stdout("Exception while displaying resources for {}: {}\n".format(
+                model_id,
+                traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__)))
+            
     def stop_selected_models(self, event):
-        srows = self.param_table.get_selected_rows()
-        self.debug.append_stdout("Stop rows {}\n".format(srows))
+        def stop_callback(fut):
+            model_id = None
+            try:
+                model_id = fut.result()
+                self.update_row(model_id, {"status": "Stopped"})
+                self._display_controls(model_id)
+            except Exception as e:
+                if model_id is not None:
+                    self.debug.append_stdout("Exception while stopping Model {} : {}\n".format(
+                        model_id,
+                        traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__)))
+                else:
+                    self.debug.append_stdout("Exception while stopping Model, future failed: {}\n".format(
+                        traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__)))
+        
+        try:
+            self.debug.append_stdout("Stop event: {}\n".format(event))
+            srows = self.param_table.get_selected_rows()
+            self.debug.append_stdout("Stop rows {}\n".format(srows))
 
-        #for row_id in srows:
-        #    model_id = self.param_table.get_changed_df().index[row_id]
+            stop_results = {}
+            with concurrent.futures.ThreadPoolExecutor(max_workers=len(srows)) as executor:
+                for row_id in srows:
+                    model_id = self.param_table.get_changed_df().index[row_id]
+                    self.update_row(model_id, {"status": "Stopping"})
+                    stop_results[model_id] = executor.submit(self._model_controller.stop_model, model_id)
+
+                    # in case the model output updated the table status in between
+                    self.update_row(model_id, {"status": "Stopping"})
+                    stop_results[model_id].add_done_callback(stop_callback)
+                self.debug.append_stdout("Done with stop_selected_models")
+        except Exception as e:
+            self.debug.append_stdout("Exception while stopping models: {}".format(
+                traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__)))
     
     def restart_selected_models(self, event):
-        srows = self.param_table.get_selected_rows()
-        self.debug.append_stdout("Restart rows {}\n".format(srows))
-        
-        #for row_id in srows:
-        #    model_id = self.param_table.get_changed_df().index[row_id]
+        try:
+            # TODO - check that models are stopped
+            self.debug.append_stdout("Restart event: {}\n".format(event))
+
+            srows = self.param_table.get_selected_rows()
+            self.debug.append_stdout("Restart rows {}\n".format(srows))
+            table_data = self.param_table.get_changed_df()
+            param_keys = [k for k in self.compute_params]
+            for row_id in srows:
+                model_id = table_data.index[row_id]
+                self.model_data[model_id] = ModelTaskData(["epoch","loss","val_loss","acc","val_acc"],["status","epoch"])
+                edited_values = self._edit_selected_rows.get_values()
+                edited_values.update({
+                    "status": "Starting",
+                    "epoch": -1,
+                    "loss": np.nan,
+                    "val_loss": np.nan,
+                    "acc": np.nan,
+                    "val_acc": np.nan
+                })
+                self.update_row(model_id, edited_values)
+                time.sleep(0.1)
+                params = table_data.loc[row_id, param_keys].to_dict()
+                self.debug.append_stdout("Starting new model {} with params {}".format(model_id, params))
+                self.debug.append_stdout("Resetting model plot")
+                self.model_displays[model_id] = None
+                self.model_plots[model_id] = self.vis_func(title="Model {}: {}".format(model_id, params))
+                plot_data = self.model_data[model_id].get_plot_data()
+                self.model_plots[model_id].update(plot_data)
+
+                self._model_controller.start_model(
+                    model_id,
+                    self.compute_func,
+                    params
+                )
+                
+                if self._active_plot == model_id:
+                    self.display_selected({'old': [model_id], 'new': [model_id]}, self.param_table, refresh=True)
+                
+                self.debug.append_stdout("Updating table status for row {}".format(row_id))
+                self.param_table._handle_qgrid_msg_helper({'type': 'selection_changed', 'rows': [row_id]})
+        except Exception as e:
+            self.debug.append_stdout("Exception while restarting models: {}".format(
+                traceback.format_exception(etype=e.__class__, value=e, tb=e.__traceback__)))
 
     def get_resource_usage(self, model_id):
-        pass
+        return self._model_controller.get_worker_resources(model_id)
     
     def get_models_status(self):
         status = self.param_table.get_changed_df()[["status"]]
+        
+    def get_model_results(self):
+        table_data = self.param_table.get_changed_df()
+        params = [k for k in self.compute_params]
+        model_results = {}
 
+        for i in range(len(self.model_data)):
+            model_results[i] = {
+                "parameters": table_data.loc[i, params].to_dict(),
+                "history": self.model_data[i].get_plot_data()
+            }
+        
+        return model_results
+
+def _get_ipp_engine_pid():
+    import os
+    return os.getpid()
 
 class ModelController(object):
     def __init__(self, ipp_cluster_id=None):
@@ -377,18 +645,158 @@ class ModelController(object):
         self._active_models = {}
         self._completed_models = {}
         self._ipp_client = ipp.Client(cluster_id=ipp_cluster_id)
-        self._lview = self._ipp_client.load_balanced_view()
+        self._ipp_engines = {}
+        self._model_id_to_ipp_engine = {}
+        
+        for x in self._ipp_client.ids:
+            self._ipp_engines[x] = {
+                "direct_view": self._ipp_client[x],
+                "pid": self._ipp_client[x].apply_sync(_get_ipp_engine_pid),
+                "busy": False,
+                "model_id": -1
+            }
+        
+        self._kale_manager = KaleManagerClient("kale_manager")
+        self._kale_workers = []
+        
+        for w in self._kale_manager.list_workers():
+            try:
+                kwc = KaleWorkerClient(w["host"],w["port"])
+                self._kale_workers.append(kwc)
+            except:
+                pass
+            
+    def _get_available_engine(self):
+        for x in self._ipp_engines:
+            if self._ipp_engines[x]["busy"]:
+                continue
+            else:
+                return x
+        else:
+            # all engines are busy, find the least busy one
+            min_queue = 2**64
+            min_engine = 0
+            for x in self._ipp_engines:
+                tmp = self._ipp_client.queue_status()[x]['queue']
+                if tmp < min_queue:
+                    min_queue = tmp
+                    min_engine = x
+            return min_engine
+
+    def _find_kale_worker_by_model_id(self, model_id):
+        if model_id not in self._model_id_to_ipp_engine:
+            return None
+        
+        engine_pid = self._ipp_engines[self._model_id_to_ipp_engine[model_id]]["pid"]
+        
+        for w in self._kale_workers:
+            #print(w.get_tasks()['1']["pid"], engine_pid, w.get_tasks()['1']["pid"] == engine_pid)
+            if w.get_tasks()['1']["pid"] == engine_pid:
+                return w
+        else:
+            return None
 
     def start_model(self, model_id, compute_func, params):
-        self._futures.append(self._lview.apply(compute_func, **params))
+        # don't bother if model is running
+        if model_id in self._active_models:
+            return
+        
+        #print("Starting model {}".format(model_id))
+        x = self._get_available_engine()
+        #print("Engine {} is available, submitting".format(x))
+        self._futures.append(self._ipp_engines[x]["direct_view"].apply(compute_func, **params))
+        self._ipp_engines[x]["model_id"] = model_id
+        self._ipp_engines[x]["busy"] = True
         self._active_models[model_id] = len(self._futures) - 1
+        self._model_id_to_ipp_engine[model_id] = x
 
     def stop_model(self, model_id):
-        pass
-    
-    def restart_model(self, model_id, compute_func, params):
-        #self._futures[model_id] = self._lview.apply(compute_func, **params)
-        pass
+        # don't bother if model is not running
+        if model_id not in self._active_models:
+            return model_id
+        
+        # get the current number of ipengines
+        num_engines = len(self._ipp_engines)
+        
+        # get the correct worker
+        w = self._find_kale_worker_by_model_id(model_id)
+        
+        #print(self._ipp_client.ids)
+        #print(w.get_tasks())
+        #print("Stopping engine for model {}".format(model_id))
+        
+        # stop the ipengine
+        w.stop_task('1')
+        
+        status = w.get_task_status(1)
+        while status in ["sleeping", "running"]:
+            #print(status)
+            time.sleep(0.5)
+            status = w.get_task_status('1')
+        
+        #print(status)
+        #print("Engine stopped, cleaning reference and restarting...")
+        
+        # clean up engine reference
+        del self._ipp_engines[self._model_id_to_ipp_engine[model_id]]
+
+        self._ipp_client._unregister_engine({'content': {'id': self._model_id_to_ipp_engine[model_id]}})
+        
+        # wait for engine to unregister
+        engine_ids = self._ipp_client.ids
+        while len(engine_ids) == num_engines:
+            time.sleep(0.5)
+            engine_ids = self._ipp_client.ids
+        
+        #print(engine_ids)
+        
+        # start a new ipengine for accepting another model run
+        w.start_task('1')
+        
+        status = w.get_task_status('1')
+        while status not in ["sleeping", "running"]:
+            #print(status)
+            time.sleep(0.5)
+            status = w.get_task_status('1')
+        
+        #print(status)
+        #print("Engine restarted")
+        
+        # refresh ipyparallel engine ids
+        engine_ids = self._ipp_client.ids
+        #print(engine_ids)
+        while len(engine_ids) < num_engines:
+            time.sleep(0.5)
+            engine_ids = self._ipp_client.ids
+
+        # add engine details
+        new_engine_ids = [e for e in self._ipp_client.ids if e not in self._ipp_engines]
+        #print(new_engine_ids)
+        if len(new_engine_ids) >= 1:
+            x = new_engine_ids[0]
+        else:
+            raise Exception("No new ipengine available!")
+        
+        del self._model_id_to_ipp_engine[model_id]
+        #print("Connecting to ipengine {}".format(x))
+        #print("Getting a DirectView to {}".format(x))
+        engine_dv = self._ipp_client[x]
+        #print("Getting ipengine pid")
+        engine_pid = engine_dv.apply_sync(_get_ipp_engine_pid)
+        #print("Saving...")
+        self._ipp_engines[x] = {
+                "direct_view": engine_dv,
+                "pid": engine_pid,
+                "busy": False,
+                "model_id": -1
+        }
+        #print("Dropping old references, setting stopped model to completed")
+        # drop old model reference
+        self._futures[self._active_models[model_id]] = None
+        del self._active_models[model_id]
+        self._completed.append(model_id)
+        #print("Done with stop_model")
+        return model_id
     
     def set_model_completed(self, model_id):
         if model_id not in self._completed:
@@ -405,6 +813,13 @@ class ModelController(object):
                 del self._active_models[i]
         
         return {k: self._futures[self._active_models[k]] for k in self._active_models}
+    
+    def get_worker_resources(self, model_id):
+        w = self._find_kale_worker_by_model_id(model_id)
+        if w is not None:
+            return w.get_task_resources('1')
+        else:
+            return {}
 
 
 class ModelTaskData(object):


### PR DESCRIPTION
There are quite a few updates included here, all meant to work together.

This update incorporates functionality from Kale for stopping/restarting the models.
There were some issues with editing the qgrid table while many updates were happening which made it very difficult to directly edit the table for updating parameters of stopped models.  The workaround was to build a small control panel using ipywidgets that allows for parameter editing, and logic is included to present these controls only when the model is completed or otherwise stopped.

This also places the model output in a tab, with a second tab dedicated to resource usage information provided by Kale.  This includes host level and task level information about cpu, memory, disk, and network usage.

There are some minor changes to the example MNIST notebook cells, mainly to make it easier to follow along and modify, and a code snippet at the bottom for how to retrieve the model data for further analysis.