### PR TITLE
Manager info, kale launch scripts, rpv input updates

### DIFF
--- a/DistWidgetHPO_rpv.ipynb
+++ b/DistWidgetHPO_rpv.ipynb
@@ -4,12 +4,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Distributed random-search hyper-parameter optimization of the Keras RPV classifier with interative widgets"
+    "# Distributed random-search hyper-parameter optimization of the Keras RPV classifier with interactive widgets"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,44 +40,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)\n",
-      "          13275748      resv       sh sfarrell  R      26:43      8 nid0[1393-1400]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%bash\n",
-    "squeue -u sfarrell"
+    "%%bash --out job_id\n",
+    "#capture the jobid to a variable\n",
+    "squeue -u $USER | awk '{if (NR!=1) {printf \"%s\", $1}}'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Worker IDs: [0, 1, 2, 3, 4, 5, 6, 7]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Cluster ID taken from job ID above\n",
-    "job_id = 13275748\n",
     "cluster_id = 'cori_{}'.format(job_id)\n",
+    "print(cluster_id)\n",
     "\n",
     "# Use default profile\n",
     "c = ipp.Client(timeout=60, cluster_id=cluster_id)\n",
-    "print('Worker IDs:', c.ids)"
+    "print('Worker IDs:', c.ids)\n",
+    "\n",
+    "mgr_info=(\"Kale Manager IP Here\", 8099)"
    ]
   },
   {
@@ -89,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +96,7 @@
     "np.random.seed(0)\n",
     "\n",
     "# Define the hyper-parameter search points\n",
-    "n_hpo_trials = 4 #48\n",
+    "n_hpo_trials = 8 #48\n",
     "h1 = np.random.choice([4, 8, 16, 32, 64], size=n_hpo_trials)\n",
     "h2 = np.random.choice([4, 8, 16, 32, 64], size=n_hpo_trials)\n",
     "h3 = np.random.choice([8, 16, 32, 64, 128], size=n_hpo_trials)\n",
@@ -122,9 +108,9 @@
     "\n",
     "# Training config\n",
     "batch_size = 64\n",
-    "n_epochs = 2 #16\n",
-    "checkpoint_dir = '/global/cscratch1/sd/sfarrell/cori-interactive-dl/rpv_hpo_%i' % job_id\n",
-    "os.makedirs(checkpoint_dir)"
+    "n_epochs = 16\n",
+    "checkpoint_dir = os.path.expandvars('/global/cscratch1/sd/$USER/cori-interactive-dl/rpv_hpo_%i'.format(job_id))\n",
+    "os.makedirs(checkpoint_dir, exist_ok=True)"
    ]
   },
   {
@@ -136,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,6 +134,7 @@
     "    import keras\n",
     "    from rpv import build_model, train_model, load_file\n",
     "    from mlextras import configure_session, IPyParallelLogger\n",
+    "\n",
     "    print('Hyperparameters: conv %s fc %s dropout %.3f opt %s, lr %.4f' %\n",
     "          (conv_sizes, fc_sizes, dropout, optimizer, lr))\n",
     "    # Load the dataset\n",
@@ -171,24 +158,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8dc1dba7b12f453fae791b31b4c779c9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "ParamSpanWidget(children=(Output(layout=Layout(border='1px solid', height='600px', overflow_x='scroll', overfl…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
    "source": [
     "train_func = partial(build_and_train, input_dir=input_dir,\n",
     "                     n_train=n_train, n_valid=n_valid,\n",
@@ -204,46 +178,54 @@
     ")\n",
     "\n",
     "hpo_params = dict(\n",
-    "    conv_sizes=conv_sizes,\n",
-    "    fc_sizes=fc_sizes,\n",
-    "    dropout=dropout,\n",
-    "    optimizer=optimizer,\n",
-    "    lr=lr,\n",
+    "    conv_sizes=dict(\n",
+    "        values=conv_sizes,\n",
+    "        default=conv_sizes[0],\n",
+    "        type=list\n",
+    "    ),\n",
+    "    fc_sizes=dict(\n",
+    "        values=fc_sizes,\n",
+    "        default=fc_sizes[0],\n",
+    "        type=list\n",
+    "    ),\n",
+    "    dropout=dict(\n",
+    "        values=dropout,\n",
+    "        default=dropout[0],\n",
+    "        type=float\n",
+    "    ),\n",
+    "    optimizer=dict(\n",
+    "        values=optimizer,\n",
+    "        default=optimizer[0],\n",
+    "        type=str,\n",
+    "        options=['Adadelta', 'Adam', 'Nadam']\n",
+    "    ),\n",
+    "    lr=dict(\n",
+    "        values=lr,\n",
+    "        default=lr[0],\n",
+    "        type=float\n",
+    "    )\n",
     ")\n",
     "\n",
     "psw = ParamSpanWidget(\n",
     "    compute_func=train_func, \n",
     "    vis_func=plot_func, \n",
     "    params=hpo_params,\n",
-    "    ipp_cluster_id=cluster_id\n",
+    "    ipp_cluster_id=cluster_id,\n",
+    "    kale_manager=mgr_info\n",
     ")\n",
     "\n",
     "psw.submit_computations()\n",
+    "\n",
     "psw"
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {
-    "scrolled": true
-   },
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# Load-balanced view\n",
-    "lv = c.load_balanced_view()\n",
-    "\n",
-    "# Loop over hyper-parameter sets\n",
-    "results = []\n",
-    "for ihp in range(n_hpo_trials):\n",
-    "    print('Hyperparameter trial %i conv %s fc %s dropout %.4f opt %s, lr %.4f' %\n",
-    "          (ihp, conv_sizes[ihp], fc_sizes[ihp], dropout[ihp], optimizer[ihp], lr[ihp]))\n",
-    "    checkpoint_file = os.path.join(checkpoint_dir, 'model_%i.h5' % ihp)\n",
-    "    result = lv.apply(build_and_train,\n",
-    "                      input_dir, n_train, n_valid,\n",
-    "                      conv_sizes=conv_sizes[ihp], fc_sizes=fc_sizes[ihp],\n",
-    "                      dropout=dropout[ihp], optimizer=optimizer[ihp], lr=lr[ihp],\n",
-    "                      batch_size=batch_size, n_epochs=n_epochs,\n",
-    "                      checkpoint_file=checkpoint_file)\n",
-    "    results.append(result)"
+    "psw.debug"
    ]
   },
   {
@@ -488,9 +470,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "isc-ihpc",
+   "display_name": "Python [conda env:isc-ihpc]",
    "language": "python",
-   "name": "isc-ihpc"
+   "name": "conda-env-isc-ihpc-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/MNIST_Widgets.ipynb
+++ b/MNIST_Widgets.ipynb
@@ -13,7 +13,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ipcluster_magics"
+    "%%bash --out job_id\n",
+    "#capture the jobid to a variable\n",
+    "squeue -u $USER | awk '{if (NR!=1) {printf \"%s\", $1}}'"
    ]
   },
   {
@@ -23,10 +25,20 @@
    "outputs": [],
    "source": [
     "job_name = \"isc_ihpc_mnist\"\n",
-    "nodes = 1\n",
-    "module = \"python/3.6-anaconda-4.4\"\n",
+    "nodes = 8\n",
+    "module = \"python/3.6-anaconda-5.2\"\n",
     "conda_env = \"/global/cscratch1/sd/sfarrell/conda/isc-ihpc\"\n",
-    "cluster_id=None"
+    "cluster_id=\"cori_{}\".format(job_id)\n",
+    "mgr_info=(\"Kale Manager IP Here\", 8099)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipcluster_magics"
    ]
   },
   {
@@ -147,7 +159,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "n_hpo_trials = 4\n",
+    "n_hpo_trials = 8\n",
     "grid_h1 = np.random.choice([4, 8, 16, 32, 64], size=n_hpo_trials)\n",
     "grid_h2 = np.random.choice([4, 8, 16, 32, 64], size=n_hpo_trials)\n",
     "grid_h3 = np.random.choice([8, 16, 32, 64, 128], size=n_hpo_trials)\n",
@@ -209,7 +221,8 @@
     "    run_training, \n",
     "    plot_metrics, \n",
     "    hpo_params,\n",
-    "    ipp_cluster_id=cluster_id)\n",
+    "    ipp_cluster_id=cluster_id,\n",
+    "    kale_manager=mgr_info)\n",
     "\n",
     "psw.submit_computations()\n",
     "\n",
@@ -334,9 +347,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "isc-ihpc",
+   "display_name": "Python [conda env:isc-ihpc]",
    "language": "python",
-   "name": "isc-ihpc"
+   "name": "conda-env-isc-ihpc-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -348,7 +361,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/hpo_widgets.py
+++ b/hpo_widgets.py
@@ -204,7 +204,7 @@ class ModelParamEditor(ipw.HBox):
 
 class ParamSpanWidget(ipw.VBox):
     def __init__(self, compute_func, vis_func, params, columns=None, ipp_cluster_id=None, 
-                 output_layout=None, qgrid_layout=None):
+                 output_layout=None, qgrid_layout=None, kale_manager=None):
         """
         compute_func: function 
         task to submit to IPyParallel for model output
@@ -331,7 +331,7 @@ class ParamSpanWidget(ipw.VBox):
         self.model_resource_displays = [None for i in range(self._num_models)]
         self.model_data = [
             ModelTaskData(["epoch","loss","val_loss","acc","val_acc"],["status","epoch"]) for i in range(self._num_models)]
-        self._model_controller = ModelController(ipp_cluster_id=ipp_cluster_id)
+        self._model_controller = ModelController(ipp_cluster_id=ipp_cluster_id, kale_manager=kale_manager)
 
         # select the first row by default
         self._active_plot = 0
@@ -639,7 +639,10 @@ def _get_ipp_engine_pid():
     return os.getpid()
 
 class ModelController(object):
-    def __init__(self, ipp_cluster_id=None):
+    def __init__(self, ipp_cluster_id=None, kale_manager=None):
+        if kale_manager is None or len(kale_manager) != 2:
+            raise TypeError("Missing Kale Manager details for ModelController, received {}".format(kale_manager))
+
         self._futures = []
         self._completed = []
         self._active_models = {}
@@ -656,7 +659,7 @@ class ModelController(object):
                 "model_id": -1
             }
         
-        self._kale_manager = KaleManagerClient("kale_manager")
+        self._kale_manager = KaleManagerClient(kale_manager[0], kale_manager[1])
         self._kale_workers = []
         
         for w in self._kale_manager.list_workers():

--- a/startKaleCluster.sh
+++ b/startKaleCluster.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+#. setup.sh
+
+# Get the IP address of our head node
+headIP=$(ip addr show ipogif0 | grep '10\.' | awk '{print $2}' | awk -F'/' '{print $1}')
+
+# Use a unique cluster ID for this job
+clusterID="cori_${SLURM_JOB_ID}"
+echo "Launching IPyParallel Controller..."
+./start_kale_task.py --mhost="$1" --mport="$2" --ipcontroller --task_args="--ip=\"$headIP\" --cluster-id=\"$clusterID\"" &
+ 
+sleep 20
+
+echo "Launching $3 IPyParallel Engines..."
+srun -N "$3" ./start_kale_task.py --mhost="$1" --mport="$2" --ipengine --task_args="--cluster-id=\"$clusterID\""

--- a/start_kale_task.py
+++ b/start_kale_task.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+from kale.services.worker import get_kale_id, spawn_worker, KaleWorkerClient
+from kale.services.manager import KaleManagerClient
+
+import argparse
+import importlib
+import requests
+import sys
+import time
+
+def launch_ipengine(*args, **kwargs):
+    import ipyparallel.apps.ipengineapp as ipe
+
+    if args:
+        ipe.launch_new_instance(argv=args)
+    else:
+        ipe.launch_new_instance()
+
+def launch_ipcontroller(*args, **kwargs):
+    import ipyparallel.apps.ipcontrollerapp as ipc
+
+    print(args)
+
+    if args:
+        ipc.launch_new_instance(argv=args)
+    else:
+        ipc.launch_new_instance()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mhost", help="Kale Manager Host IP")
+    parser.add_argument("--mport", help="Kale Manager Port", type=int)
+    launchers = parser.add_mutually_exclusive_group(required=True)
+    launchers.add_argument("--ipcontroller", help="Launch ipcontroller", action='store_true')    
+    launchers.add_argument("--ipengine", help="Launch ipengine", action='store_true')
+    parser.add_argument("--task_args", help="Task command line args string")
+
+    args = parser.parse_args()
+
+    _mhost = "127.0.0.1"
+    if args.mhost:
+        _mhost = args.mhost
+
+    _mport = 8099
+    if args.mport:
+        _mport = args.mport
+
+    _task = None
+    if args.ipcontroller:
+        _task = launch_ipcontroller
+    elif args.ipengine:
+        _task = launch_ipengine
+
+    _task_args = []
+    if args.task_args:
+        _task_args = args.task_args.split()
+
+    mgr = KaleManagerClient(_mhost, _mport)
+
+    # spawn kale worker
+    print("Starting Kale Worker...")
+    kale_id = get_kale_id()
+    w = spawn_worker(kale_id, whost="0.0.0.0", mhost=_mhost, mport=_mport)
+
+    while 1:
+        print("Waiting for worker connection info...")
+        try:
+            info = mgr.get_worker(kale_id)
+            print(info)
+            break
+        except requests.HTTPError:
+            time.sleep(0.1)
+
+    kale_worker = KaleWorkerClient(info["host"], info["port"])
+
+    while 1:
+        print("Waiting for worker to start listening...")
+        try:
+            kale_worker.get_service_status()
+            break
+        except requests.ConnectionError:
+            time.sleep(0.1)
+
+    # launch engine
+    print("Starting Kale Task with args {}...".format(_task_args))
+    kale_task = kale_worker.register_function_task(
+        _task,
+        _task_args)
+    kale_worker.start_task(kale_task)


### PR DESCRIPTION
* Propagate Manager info through from the ParamSpanWidget init
* added scripts for launching the ipcluster with kale on cori
* input updates for rpv notebook to specify type of each input, defaults, for display and widget input forms