### PR TITLE
bugfixes for model restart, stop status update, checking for resources after model has stopped 

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 # Using a conda env
-module load python
-. activate /global/cscratch1/sd/sfarrell/conda/isc-ihpc
+#module load python
+#. activate /global/cscratch1/sd/sfarrell/conda/isc-ihpc
 
 # Set some threading variables
 export NUM_INTER_THREADS=2

--- a/startKaleCluster.sh
+++ b/startKaleCluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#. setup.sh
+. setup.sh
 
 # Get the IP address of our head node
 headIP=$(ip addr show ipogif0 | grep '10\.' | awk '{print $2}' | awk -F'/' '{print $1}')


### PR DESCRIPTION
**Bugfixes**
- fix model restart in rpv example notebook with list inputs, properly converting to/from string where needed
- stop resource checking after model has stopped (on last update iteration)
- wait for "Stopped" status in table before ending stop callback
- unset busy flag for engine when model finishes 

**Updates**
- updates cluster start script to use environment setting in setup.sh